### PR TITLE
Add GitHub Pages Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,45 @@
+name: deploy
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
+jobs:
+  app:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.5.3
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3.0.6
+
+      - name: Cache deps
+        uses: actions/cache@v3.3.1
+        with:
+          path: node_modules
+          key: node-${{ hashFiles('package-lock.json') }}
+
+      - name: Install deps
+        run: npm install
+
+      - name: Build app
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2.0.0
+        with:
+          path: dist
+
+      - name: Deploy App
+        id: deployment
+        uses: actions/deploy-pages@v2.0.3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # React-TypeScript Starter
 
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/react-ts-starter/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/react-ts-starter/actions/workflows/build.yaml)
+[![deploy status](https://img.shields.io/github/actions/workflow/status/threeal/react-ts-starter/deploy.yaml?branch=main&label=deploy&style=flat-square)](https://github.com/threeal/react-ts-starter/actions/workflows/deploy.yaml)
 
 Kickstart your [React](https://react.dev/) project with [TypeScript](https://www.typescriptlang.org/) using this minimalistic [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template).

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "/react-ts-starter",
   plugins: [react()],
 })


### PR DESCRIPTION
This pull request introduces a new `deploy.yaml` workflow that enables automatic deployment of the application to [GitHub Pages](https://pages.github.com/). Additionally, this pull request closes #6.