### PR TITLE
Remove Configure Pages Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,9 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5.0.0
-
       - name: Cache deps
         uses: actions/cache@v3.3.2
         with:


### PR DESCRIPTION
This pull request resolves #149 by removing the Configure Pages action from the Deploy Pages job.