### PR TITLE
Utilize Threeal's Cache Action in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,11 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Cache deps
-        uses: actions/cache@v4.0.2
+        uses: threeal/cache-action@v0.1.0
         with:
-          path: node_modules
-          key: node-${{ hashFiles('package-lock.json') }}
+          key: node
+          version: ${{ hashFiles('package-lock.json') }}
+          files: node_modules
 
       - name: Install deps
         run: npm install

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,10 +21,11 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Cache deps
-        uses: actions/cache@v4.0.2
+        uses: threeal/cache-action@v0.1.0
         with:
-          path: node_modules
-          key: node-${{ hashFiles('package-lock.json') }}
+          key: node
+          version: ${{ hashFiles('package-lock.json') }}
+          files: node_modules
 
       - name: Install deps
         run: npm install


### PR DESCRIPTION
This pull request resolves #229 by replacing [actions/cache](https://github.com/actions/cache) with [threeal/cache-action](https://github.com/threeal/cache-action) in the workflows.