### PR TITLE
Add Git Attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+**/*.svg -diff
+pnpm-lock.yaml -diff linguist-generated


### PR DESCRIPTION
This pull request resolves #446 by adding a `.gitattributes` file that disable diff to the `*.svg` and `pnpm-lock.yaml files. It also set generated attribute to the `pnpm-lock.yaml` file.